### PR TITLE
Linux

### DIFF
--- a/calculate.csh
+++ b/calculate.csh
@@ -58,7 +58,7 @@ if ($count > 28) then
     
 
     #run nawkscript to calculate averages and mins
-    gawk -F" " -f $SPACE_Wdir/process_ace.gawk $SPACE_Wdir/last45 > $SPACE_Wdir/acedata
+    gawk -F" " -f $SPACE_Wdir/process_ace.nawk $SPACE_Wdir/last45 > $SPACE_Wdir/acedata
     #smart_proc#
     # if P3 might be good turn on "smarter" processing, 
     #  -comment out 1 line above ( nawf -F ...)

--- a/calculate.csh
+++ b/calculate.csh
@@ -77,8 +77,8 @@ lynx -source http://services.swpc.noaa.gov/images/ace-mag-swepam-7-day.gif >! $W
 #sed s/'<CENTER><IMG SRC="'/''/1 $SPACE_Wdir/tmpkp | sed s/'"><'/' '/1 | sed s/'\/CENTER>'/''/1 >! $SPACE_Wdir/kpimagename
 #set image_varkp=`cat $SPACE_Wdir/kpimagename`
 
-##lynx -source http://www.swpc.noaa.gov/wingkp/wingkp_15m_24h.gif >!  $WEBdir/wingkp.gif
-##usr/bin/convert -negate  $WEBdir/wingkp.gif - >! $WEBdir/wingkp_i.gif
+lynx -source http://services.swpc.noaa.gov/images/wing-kp-24-hour.gif >!  $WEBdir/wingkp.gif
+/usr/bin/convert -negate  $WEBdir/wingkp.gif - >! $WEBdir/wingkp_i.gif
 
 cat $SPACE_Wdir/header $SPACE_Wdir/acedata  $SPACE_Wdir/image2 $SPACE_Wdir/rob1 $SPACE_Wdir/footer >! $WEBdir/ace.html
 

--- a/calculate.csh
+++ b/calculate.csh
@@ -65,7 +65,6 @@ if ($count > 28) then
 lynx -source http://services.swpc.noaa.gov/images/ace-epam-7-day.gif | /usr/bin/convert -negate - - >! $WEBdir/Epam_7di.gif
 lynx -source http://services.swpc.noaa.gov/images/ace-epam-7-day.gif >! $WEBdir/Epam_7d.gif
 lynx -source http://services.swpc.noaa.gov/images/ace-epam-7-day.gif >! $WEBdir/mta_ace_plot.gif
-/usr/bin/convert -negate $WEBdir/mta_ace_plot.gif $WEBdir/Epam_7di.gif
 /usr/bin/convert -negate $WEBdir/mta_ace_plot_P3.gif $WEBdir/Epam_7di_P3.gif
 
 # get wind speed etc. plot

--- a/calculate.csh
+++ b/calculate.csh
@@ -22,11 +22,8 @@
 #scrapper>mv prot_violate_ESTKP  prot_violate_ESTKP.08Jun2000
 #scrapper>mv prot_violate prot_violate.08Jun2000
 
-
-
 set SPACE_Wdir=/data/mta4/space_weather
 set WEBdir=/data/mta4/www
-set WAPdir=/data/mta4/www/WL
 
 #set today=`date '+%y%m%d'`
 
@@ -45,10 +42,8 @@ set file = ftp://ftp.sec.noaa.gov/pub/lists/ace/ace_epam_5m.txt
 
 /bin/rm $SPACE_Wdir/returned
 lynx -source $file > $SPACE_Wdir/returned
-#lynx -source http://solar.sec.noaa.gov/getftp.cgi\?get=lists/ace/ace_epam_5m.txt > $SPACE_Wdir/returned
 
 set count = `cat $SPACE_Wdir/returned | wc -l`
-#echo $count
 
 if ($count > 28) then 
    /bin/rm $SPACE_Wdir/last45
@@ -65,17 +60,11 @@ if ($count > 28) then
     #  -uncomment line below (process_ace3.0.pl)
     #  -leave wap processing, it's all we've got
     #smart_proc#$SPACE_Wdir/process_ace3.0.pl > $SPACE_Wdir/acedata
-    #nawk -F" " -f $SPACE_Wdir/proc_ace_wap1.nawk $SPACE_Wdir/last45 > $WAPdir/ace.wml
-    #nawk -F" " -f $SPACE_Wdir/proc_ace_wap2.nawk $SPACE_Wdir/last45 >> $WAPdir/ace.wml
-    #nawk -F" " -f $SPACE_Wdir/proc_ace_wap1_p5.nawk $SPACE_Wdir/last45 > $WAPdir/ace_scaled.wml
-    #nawk -F" " -f $SPACE_Wdir/proc_ace_wap2_p5.nawk $SPACE_Wdir/last45 >> $WAPdir/ace_scaled.wml
-#    rm /data/mta4/www/ace.html
 
 #go collect ACE image and invert. 
 lynx -source http://services.swpc.noaa.gov/images/ace-epam-7-day.gif | /usr/bin/convert -negate - - >! $WEBdir/Epam_7di.gif
 lynx -source http://services.swpc.noaa.gov/images/ace-epam-7-day.gif >! $WEBdir/Epam_7d.gif
 lynx -source http://services.swpc.noaa.gov/images/ace-epam-7-day.gif >! $WEBdir/mta_ace_plot.gif
-/usr/bin/convert -negate $WEBdir/Epam_7d.gif $WEBdir/Epam_7di.gif
 /usr/bin/convert -negate $WEBdir/mta_ace_plot.gif $WEBdir/Epam_7di.gif
 /usr/bin/convert -negate $WEBdir/mta_ace_plot_P3.gif $WEBdir/Epam_7di_P3.gif
 
@@ -89,28 +78,11 @@ lynx -source http://services.swpc.noaa.gov/images/ace-mag-swepam-7-day.gif >! $W
 #set image_varkp=`cat $SPACE_Wdir/kpimagename`
 
 ##lynx -source http://www.swpc.noaa.gov/wingkp/wingkp_15m_24h.gif >!  $WEBdir/wingkp.gif
-/##usr/bin/convert -negate  $WEBdir/wingkp.gif - >! $WEBdir/wingkp_i.gif
-
-
-
-#THIS FILE EXISTS AND IS STATIC, NO NEED TO RECREATE IN-LINE.
-#echo '<HR> <li><a href ="alerts/ace.archive"> 3-day archive </a>of the latest ACE data.' >! $SPACE_Wdir/rob1
-#echo '<li><a href="alerts/fluance.dat"> Latest orbital fluance when CHANDRA is above 70kkm. </a>'  >>  $SPACE_Wdir/rob1
-#echo '<li><a href="alerts/ace_fluence.arc"> History of fluance when CHANDRA has been above 70kkm. </a>'  >>  $SPACE_Wdir/rob1
-#echo '<li><a href="alerts/about_ace_page.html"> About our ACE Monitoring and Alerts.</a>'  >>  $SPACE_Wdir/rob1
-
-#sec #echo '<HR><CENTER><IMG SRC="http://sec.noaa.gov/ace/'$image_var'"></CENTER>' >! $SPACE_Wdir/image
-#echo '<HR><CENTER><IMG SRC="http://www.sec.noaa.gov/ace/Epam_7d.gif'"></CENTER>' >! $SPACE_Wdir/image2
-#/opt/local/bin/lynx -source http://www.sec.noaa.gov/rpc/costello/$image_varkp | /opt/local/bin/convert -negate - - >! test.gif
-#sec #echo '<HR><CENTER><IMG SRC="http://www.sec.noaa.gov/rpc/costello/'$image_varkp'"></CENTER>' >! $SPACE_Wdir/kpimage
-#echo '<HR><CENTER><IMG SRC="http://www.sec.noaa.gov/rpc/costello/'$image_varkp'"></CENTER>' >! $SPACE_Wdir/kpimage
-
+##usr/bin/convert -negate  $WEBdir/wingkp.gif - >! $WEBdir/wingkp_i.gif
 
 cat $SPACE_Wdir/header $SPACE_Wdir/acedata  $SPACE_Wdir/image2 $SPACE_Wdir/rob1 $SPACE_Wdir/footer >! $WEBdir/ace.html
 
-
 cat $SPACE_Wdir/header_i $SPACE_Wdir/acedata  $SPACE_Wdir/image_i  $SPACE_Wdir/rob1 $SPACE_Wdir/footer >! $WEBdir/ace_i.html
-
 
 endif
 

--- a/calculate.csh
+++ b/calculate.csh
@@ -1,4 +1,5 @@
-#! /bin/tcsh -f
+#! /usr/bin/env /bin/csh
+
 # test2
 #
 #  THIS IS THE ACE WEB GENERATION AND ALERTS MAIL SOURCE
@@ -38,57 +39,57 @@ set WAPdir=/data/mta4/www/WL
 
 #sec set file = ftp://solar.sec.noaa.gov/pub/lists/ace/ace_epam_5m.txt
 #set file = ftp://www.sec.noaa.gov/pub/lists/ace/ace_epam_5m.txt
-#set file = ftp://ftp.sec.noaa.gov/pub/lists/ace/ace_epam_5m.txt
+set file = ftp://ftp.sec.noaa.gov/pub/lists/ace/ace_epam_5m.txt
 #set file = http://sec.noaa.gov/ftpdir/lists/ace/ace_epam_5m.txt
-set file = http://www.swpc.noaa.gov/ftpdir/lists/ace/ace_epam_5m.txt
+#set file = http://legacy-www.swpc.noaa.gov/ftpdir/lists/ace/ace_epam_5m.txt
 
-rm $SPACE_Wdir/returned
-/opt/local/bin/lynx -source $file > $SPACE_Wdir/returned
+/bin/rm $SPACE_Wdir/returned
+lynx -source $file > $SPACE_Wdir/returned
 #lynx -source http://solar.sec.noaa.gov/getftp.cgi\?get=lists/ace/ace_epam_5m.txt > $SPACE_Wdir/returned
 
 set count = `cat $SPACE_Wdir/returned | wc -l`
 #echo $count
 
 if ($count > 28) then 
-   rm $SPACE_Wdir/last45
-   rm $SPACE_Wdir/lasthour
+   /bin/rm $SPACE_Wdir/last45
+   /bin/rm $SPACE_Wdir/lasthour
     tail -24 $SPACE_Wdir/returned > $SPACE_Wdir/lasthour
     head -24 $SPACE_Wdir/lasthour > $SPACE_Wdir/last45
     
 
     #run nawkscript to calculate averages and mins
-    nawk -F" " -f $SPACE_Wdir/process_ace.nawk $SPACE_Wdir/last45 > $SPACE_Wdir/acedata
+    gawk -F" " -f $SPACE_Wdir/process_ace.gawk $SPACE_Wdir/last45 > $SPACE_Wdir/acedata
     #smart_proc#
     # if P3 might be good turn on "smarter" processing, 
     #  -comment out 1 line above ( nawf -F ...)
     #  -uncomment line below (process_ace3.0.pl)
     #  -leave wap processing, it's all we've got
     #smart_proc#$SPACE_Wdir/process_ace3.0.pl > $SPACE_Wdir/acedata
-    nawk -F" " -f $SPACE_Wdir/proc_ace_wap1.nawk $SPACE_Wdir/last45 > $WAPdir/ace.wml
-    nawk -F" " -f $SPACE_Wdir/proc_ace_wap2.nawk $SPACE_Wdir/last45 >> $WAPdir/ace.wml
-    nawk -F" " -f $SPACE_Wdir/proc_ace_wap1_p5.nawk $SPACE_Wdir/last45 > $WAPdir/ace_scaled.wml
-    nawk -F" " -f $SPACE_Wdir/proc_ace_wap2_p5.nawk $SPACE_Wdir/last45 >> $WAPdir/ace_scaled.wml
+    #nawk -F" " -f $SPACE_Wdir/proc_ace_wap1.nawk $SPACE_Wdir/last45 > $WAPdir/ace.wml
+    #nawk -F" " -f $SPACE_Wdir/proc_ace_wap2.nawk $SPACE_Wdir/last45 >> $WAPdir/ace.wml
+    #nawk -F" " -f $SPACE_Wdir/proc_ace_wap1_p5.nawk $SPACE_Wdir/last45 > $WAPdir/ace_scaled.wml
+    #nawk -F" " -f $SPACE_Wdir/proc_ace_wap2_p5.nawk $SPACE_Wdir/last45 >> $WAPdir/ace_scaled.wml
 #    rm /data/mta4/www/ace.html
 
 #go collect ACE image and invert. 
-/opt/local/bin/lynx -source http://www.sec.noaa.gov/ace/Epam_7d.gif | /opt/local/bin/convert -negate - - >! $WEBdir/Epam_7di.gif
-/opt/local/bin/lynx -source http://www.sec.noaa.gov/ace/Epam_7d.gif >!  $WEBdir/Epam_7d.gif
-/opt/local/bin/lynx -source http://www.sec.noaa.gov/ace/Epam_7d.gif >!  $WEBdir/mta_ace_plot.gif
-/opt/local/bin/convert -negate $WEBdir/Epam_7d.gif $WEBdir/Epam_7di.gif
-/opt/local/bin/convert -negate $WEBdir/mta_ace_plot.gif $WEBdir/Epam_7di.gif
-/opt/local/bin/convert -negate $WEBdir/mta_ace_plot_P3.gif $WEBdir/Epam_7di_P3.gif
+lynx -source http://services.swpc.noaa.gov/images/ace-epam-7-day.gif | /usr/bin/convert -negate - - >! $WEBdir/Epam_7di.gif
+lynx -source http://services.swpc.noaa.gov/images/ace-epam-7-day.gif >! $WEBdir/Epam_7d.gif
+lynx -source http://services.swpc.noaa.gov/images/ace-epam-7-day.gif >! $WEBdir/mta_ace_plot.gif
+/usr/bin/convert -negate $WEBdir/Epam_7d.gif $WEBdir/Epam_7di.gif
+/usr/bin/convert -negate $WEBdir/mta_ace_plot.gif $WEBdir/Epam_7di.gif
+/usr/bin/convert -negate $WEBdir/mta_ace_plot_P3.gif $WEBdir/Epam_7di_P3.gif
 
 # get wind speed etc. plot
-/opt/local/bin/lynx -source http://www.sec.noaa.gov/ace/Mag_swe_7d.gif >!  $WEBdir/Mag_swe_7d.gif
-/opt/local/bin/convert -negate $WEBdir/Mag_swe_7d.gif $WEBdir/Mag_swe_7di.gif
+lynx -source http://services.swpc.noaa.gov/images/ace-mag-swepam-7-day.gif >! $WEBdir/Mag_swe_7d.gif
+/usr/bin/convert -negate $WEBdir/Mag_swe_7d.gif $WEBdir/Mag_swe_7di.gif
 
 #go and collect Kp image 
 #/opt/local/bin/lynx -source http://www.sec.noaa.gov/rpc/costello/pkp_15m_7d.html | tail -9 | head -1 > ! $SPACE_Wdir/tmpkp
 #sed s/'<CENTER><IMG SRC="'/''/1 $SPACE_Wdir/tmpkp | sed s/'"><'/' '/1 | sed s/'\/CENTER>'/''/1 >! $SPACE_Wdir/kpimagename
 #set image_varkp=`cat $SPACE_Wdir/kpimagename`
 
-/opt/local/bin/lynx -source http://www.swpc.noaa.gov/wingkp/wingkp_15m_24h.gif >!  $WEBdir/wingkp.gif
-/opt/local/bin/convert -negate  $WEBdir/wingkp.gif - >! $WEBdir/wingkp_i.gif
+##lynx -source http://www.swpc.noaa.gov/wingkp/wingkp_15m_24h.gif >!  $WEBdir/wingkp.gif
+/##usr/bin/convert -negate  $WEBdir/wingkp.gif - >! $WEBdir/wingkp_i.gif
 
 
 


### PR DESCRIPTION
This pull makes ACE monitoring (calculate.csh) compatible on Linux.  Also we update to the new SWPC links.  No changes are needed in the supporting programs (process_ace.nawk and aceviolation_protons.csh)
The process was tested and is running as a cronjob on c3po-v, producing output at:
  https://cxc.cfa.harvard.edu/mta_days/MIRROR/ace.html
(The format of this page is identical to the current one.)

I tested the alert by setting the limit to 0 and successfully sent myself a message (via cron).
We would like to implement on the primary ACE page next Wednesday or Thursday.